### PR TITLE
doc(readme): fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Quick Start Guide
 
-- [Qucik Start: Android](http://docs.repro.io/en/quickstart/android)
+- [Quick Start: Android](http://docs.repro.io/en/quickstart/android.html)
 
 ## Documentation
 
-Read [the documentation](https://docs.repro.io) for further information
+Read [the documentation](http://docs.repro.io) for further information
 
 ## Author
 


### PR DESCRIPTION
This PR resolves incorrect links found in README.md including:
- Incorrect use of http to docs.repro.io
- Lack of .html extension to a specific URL

Please take a look and merge when you have the time, thanks.
